### PR TITLE
Added missing dependency for HibernateJpaConfiguration class.

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
Added missing dependency for issue brought up in https://github.com/spring-guides/gs-accessing-data-mysql/issues/17.

This fixes the issue for me on the following JDK version:
```
openjdk 10.0.2 2018-07-17
OpenJDK Runtime Environment (build 10.0.2+13-Ubuntu-1ubuntu0.18.04.4)
OpenJDK 64-Bit Server VM (build 10.0.2+13-Ubuntu-1ubuntu0.18.04.4, mixed mode)```
