### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 :spring_version: current
 :spring_boot_version: 2.1.3.RELEASE
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -13,7 +13,7 @@ This guide walks you through the process of creating a Spring application connec
 
 You'll create a MySQL database, build a Spring application and connect it with the newly created database.
 
-NOTE: MySQL is licensed with the GPL, so any program binary that you distribute using it must use the GPL too. Refer to the http://www.gnu.org/licenses/gpl.html[GNU General Public Licence].
+NOTE: MySQL is licensed with the GPL, so any program binary that you distribute using it must use the GPL too. Refer to the https://www.gnu.org/licenses/gpl.html[GNU General Public Licence].
 
 == What you'll need
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://www.gnu.org/licenses/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/gpl.html ([https](https://www.gnu.org/licenses/gpl.html) result 200).