### PR TITLE
Fix mysql driver error

### DIFF
--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -2,5 +2,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/db_example
 spring.datasource.username=springuser
 spring.datasource.password=ThePassword
-spring.datasource.driver-class-name =com.mysql.jdbc.Driver
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 #spring.jpa.show-sql: true


### PR DESCRIPTION
1. com.mysql.jdbc.Driver is deprecated

2. This fixes the following error : 

```
Error creating bean with name 'dataSource' defined in class path resource [org/springframework/boot/autoconfigure/jdbc/DataSourceConfiguration$Hikari.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.zaxxer.hikari.HikariDataSource]: Factory method 'dataSource' threw exception; nested exception is java.lang.IllegalStateException: Cannot load driver class: com.mysql.jdbc.Driver
```