### PR TITLE
[UPDATE] Create the application.properties File

### DIFF
--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -2,5 +2,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/db_example
 spring.datasource.username=springuser
 spring.datasource.password=ThePassword
-spring.datasource.driver-class-name =com.mysql.jdbc.Driver
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.jpa.show-sql: true


### PR DESCRIPTION
@Buzzardo please review

There's an error at https://spring.io/guides/gs/accessing-data-mysql/

PROBLEM:
When I follow the steps from the section **Accessing data with MySQL / Create the application.properties File** I receive this message:
> Loading class `com.mysql.jdbc.Driver`. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver`. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.

SOLUTION:
Need to update the following line of code:

spring.jpa.hibernate.ddl-auto=update
spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/db_example
spring.datasource.username=springuser
spring.datasource.password=ThePassword
**spring.datasource.driver-class-name =com.mysql.cj.jdbc.Driver**
#spring.jpa.show-sql: true