### PR TITLE
Fix broken `./gradlew test` and ./gradlew bootRun` commands because of missing MySQL jdbc driver

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/complete/docker-compose.yml
+++ b/complete/docker-compose.yml
@@ -1,13 +1,14 @@
-mysql:
-  image: mysql
-  ports:
-    - "3306:3306"
-  expose:
-    - "3306"
-  environment:
-    - MYSQL_USER=springuser
-    - MYSQL_PASSWORD=ThePassword
-    - MYSQL_DATABASE=db_example
-    - MYSQL_ROOT_PASSWORD=root
-  volumes:
-    - "./conf.d:/etc/mysql/conf.d:ro"
+services:
+  mysql:
+    image: mysql
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"
+    environment:
+      - MYSQL_USER=springuser
+      - MYSQL_PASSWORD=ThePassword
+      - MYSQL_DATABASE=db_example
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - "./conf.d:/etc/mysql/conf.d:ro"

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/initial/docker-compose.yml
+++ b/initial/docker-compose.yml
@@ -1,0 +1,13 @@
+mysql:
+  image: mysql
+  ports:
+    - "3306:3306"
+  expose:
+    - "3306"
+  environment:
+    - MYSQL_USER=springuser
+    - MYSQL_PASSWORD=ThePassword
+    - MYSQL_DATABASE=db_example
+    - MYSQL_ROOT_PASSWORD=root
+  volumes:
+    - "./conf.d:/etc/mysql/conf.d:ro"

--- a/initial/docker-compose.yml
+++ b/initial/docker-compose.yml
@@ -1,13 +1,14 @@
-mysql:
-  image: mysql
-  ports:
-    - "3306:3306"
-  expose:
-    - "3306"
-  environment:
-    - MYSQL_USER=springuser
-    - MYSQL_PASSWORD=ThePassword
-    - MYSQL_DATABASE=db_example
-    - MYSQL_ROOT_PASSWORD=root
-  volumes:
-    - "./conf.d:/etc/mysql/conf.d:ro"
+services:
+  mysql:
+    image: mysql
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"
+    environment:
+      - MYSQL_USER=springuser
+      - MYSQL_PASSWORD=ThePassword
+      - MYSQL_DATABASE=db_example
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - "./conf.d:/etc/mysql/conf.d:ro"

--- a/initial/src/main/resources/application.properties
+++ b/initial/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/db_example
 spring.datasource.username=springuser
 spring.datasource.password=ThePassword
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Add additional settings for the initial directory also works and does not error with `./gradlew test` or `./gradlew bootRun`.

See #57

For the docker-compose.yml issue discussed in #51 has also been fixed by adding a `services:` yaml block.